### PR TITLE
[Bug]: Added mobile table view

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
               placeholder="Search..."
             />
           </div>
-          <table>
+          <table class="interns-table">
             <thead id="interns-table-header"></thead>
             <tbody id="interns-table-body"></tbody>
           </table>

--- a/src/style.css
+++ b/src/style.css
@@ -10,9 +10,9 @@ body {
 
 main {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
+  flex-direction: row;
+  align-items: flex-start;
+  width: 95%;
   min-height: 100vh;
 }
 
@@ -97,9 +97,9 @@ section.week-card {
   box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
   padding: 30px;
   max-width: 800px;
-  margin: 20px auto;
+  margin: 10px;
   overflow: hidden;
-  min-width: 600px;
+  min-width: 500px;
 }
 
 /* Inner Week Card */
@@ -519,7 +519,7 @@ table thead th:nth-child(2) {
 .pill-select,
 .pill-select-all,
 .pill-deselect-all {
-  min-width: 96px;
+  /*min-width: 96px;*/
   padding: 10px 20px;
   border-radius: 20px;
   border: none;
@@ -611,6 +611,10 @@ table thead th:nth-child(2) {
   display: none;
 }
 
+tr:nth-child(odd) {
+  background: #e8f2ea;
+}
+
 @media screen and (width <= 768px) {
   #desktop-logo {
     display: none;
@@ -676,6 +680,12 @@ table thead th:nth-child(2) {
     width: 150px !important;
     font-size: 16px;
   }
+
+  .interns-config-settings {
+    flex-direction: column-reverse;
+  }
+
+
 }
 
 @media screen and (width <= 950px) {
@@ -693,4 +703,68 @@ table thead th:nth-child(2) {
     display: flex;
     justify-content: flex-start;
   }
+
+  main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 95%;
+    min-height: 100vh;
+  }
+
+  section.week-card {
+    min-width: 1px;
+    width: 90%;
+  }
+}
+
+@media screen and (width <= 500px) {
+  section.week-card {
+    min-width: 1px;
+    width: 80%;
+  }
+  .week-header h2 {
+    font-size: 1.5rem;
+}
+  /* Force table to not be like tables anymore */
+  table, thead, tbody, th, td, tr {
+    display: block;
+  }
+
+  /* Hide table headers (but not display: none;, for accessibility) */
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  tr {
+    margin: 0 0 1rem 0;
+  }
+    
+  
+  td {
+    /* Behave  like a "row" */
+    border: none;
+    border-bottom: 1px solid #eee;
+    position: relative;
+    padding-left: 50%;
+  }
+
+  td:before {
+    /* Top/left values mimic padding */
+    top: 0;
+    left: 6px;
+    width: 45%;
+    white-space: nowrap;
+    font-weight: bold;
+  }
+
+  /*
+  Label the data
+  You could also use a data-* attribute and content for this. That way "bloats" the HTML, this way means you need to keep HTML and CSS in sync. Lea Verou has a clever way to handle with text-shadow.
+  */
+  .interns-table td:nth-of-type(2):before { content: "Name"; }
+  .interns-table td:nth-of-type(3):before { content: "Location"; }
+
 }

--- a/src/style.css
+++ b/src/style.css
@@ -519,7 +519,7 @@ table thead th:nth-child(2) {
 .pill-select,
 .pill-select-all,
 .pill-deselect-all {
-  /*min-width: 96px;*/
+  /* min-width: 96px; */
   padding: 10px 20px;
   border-radius: 20px;
   border: none;
@@ -684,8 +684,6 @@ tr:nth-child(odd) {
   .interns-config-settings {
     flex-direction: column-reverse;
   }
-
-
 }
 
 @media screen and (width <= 950px) {
@@ -723,26 +721,33 @@ tr:nth-child(odd) {
     min-width: 1px;
     width: 80%;
   }
+
   .week-header h2 {
     font-size: 1.5rem;
-}
+  }
+
   /* Force table to not be like tables anymore */
-  table, thead, tbody, th, td, tr {
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
     display: block;
   }
 
   /* Hide table headers (but not display: none;, for accessibility) */
-  thead tr {
+  thead,
+  tr {
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
 
   tr {
-    margin: 0 0 1rem 0;
+    margin: 0 0 1rem;
   }
-    
-  
+
   td {
     /* Behave  like a "row" */
     border: none;
@@ -751,7 +756,7 @@ tr:nth-child(odd) {
     padding-left: 50%;
   }
 
-  td:before {
+  td::before {
     /* Top/left values mimic padding */
     top: 0;
     left: 6px;
@@ -764,7 +769,11 @@ tr:nth-child(odd) {
   Label the data
   You could also use a data-* attribute and content for this. That way "bloats" the HTML, this way means you need to keep HTML and CSS in sync. Lea Verou has a clever way to handle with text-shadow.
   */
-  .interns-table td:nth-of-type(2):before { content: "Name"; }
-  .interns-table td:nth-of-type(3):before { content: "Location"; }
+  .interns-table td:nth-of-type(2)::before {
+    content: "Name";
+  }
 
+  .interns-table td:nth-of-type(3)::before {
+    content: "Location";
+  }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -519,7 +519,6 @@ table thead th:nth-child(2) {
 .pill-select,
 .pill-select-all,
 .pill-deselect-all {
-  /* min-width: 96px; */
   padding: 10px 20px;
   border-radius: 20px;
   border: none;


### PR DESCRIPTION
## Changes
1. Fixed mobile spacing 

**Mobile View**
<img width="376" alt="Screen Shot 2024-10-09 at 4 41 58 PM" src="https://github.com/user-attachments/assets/d4f58c5c-34d8-4caf-bbe2-586d6b11f61f">

3. Added table view
<img width="372" alt="Screen Shot 2024-10-09 at 4 38 11 PM" src="https://github.com/user-attachments/assets/51b5dba4-1327-4d0b-bf68-67f278fe72c7">
<img width="376" alt="Screen Shot 2024-10-09 at 4 38 46 PM" src="https://github.com/user-attachments/assets/18ab47e3-344a-4dd5-82e4-262e75acdf54">

4. Made cards row view for desktop view
<img width="1265" alt="Screen Shot 2024-10-09 at 4 37 00 PM" src="https://github.com/user-attachments/assets/85b525e8-020d-4c1c-bd26-658a84104f61">


## Approach
Added modifications to the `styles.css` file to accommodate mobile view.

## Testing Steps
When viewed from mobile orientation and table view should change and be responsive.

## Learning
[Converting mobile table view](https://css-tricks.com/responsive-data-tables/)

Closes #65 
