### PR TITLE
[Fix]: Add Intern to Generated Pairs

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,16 +115,15 @@
       </section>
 
       <div id="edit-pair-modal" class="edit-modal">
-
         <!-- Modal content -->
         <div class="edit-modal-content">
           <span class="edit-close">&times;</span>
-          <table id="intern-options">Select Intern to add</table>
+          <table id="intern-options">
+            Select Intern to add
+          </table>
           <button id="submit-modal">Submit</button>
         </div>
-      
       </div>
-
     </main>
     <div id="scrollToTop" class="scroll-to-top">
       <i class="fas fa-arrow-up"></i>

--- a/src/app.js
+++ b/src/app.js
@@ -4,10 +4,9 @@ import {
   displayInternWeekTable,
   displayInternTable,
 } from "./scripts/interns.js";
+import { displayExportButton } from "./scripts/exportCSV.js";
 
 export let currentSearchQuery = "";
-import { displayExportButton } from "./scripts/exportCSV.js";
-import { internPairsSet } from "./constants/constants.js";
 
 function main() {
   displayFilters();
@@ -42,7 +41,6 @@ function main() {
   const generateButton = document.getElementById("schedule-button");
 
   generateButton.addEventListener("click", function () {
-    internPairsSet.clear();
     displayInternWeekTable();
     displayQuestions();
     displayExportButton();

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -20,7 +20,3 @@ export const filters = [
 ];
 
 export const internsSet = new Set();
-
-export const unselectedInternsSet = new Set();
-
-export const internPairsSet = new Set();

--- a/src/scripts/edit.js
+++ b/src/scripts/edit.js
@@ -1,24 +1,22 @@
-import { internPairsSet, internsSet } from "../constants/constants.js";
+import { displayInternWeekTable, getUnselectedInterns } from "./interns.js";
+import { formatInternDetails, updateInternsTable } from "./interns.js";
 import {
-  displayInternWeekTable,
-  getUnselectedInterns,
-  displayInternTable,
+  savePairsToLocalStorage,
+  loadPairsFromLocalStorage,
 } from "./interns.js";
-import { formatInternDetails } from "./interns.js";
-import { savePairsToLocalStorage } from "./interns.js";
 
-export function displayAddModal(button, pair, interns) {
+export function displayAddModal(button, pair, index) {
   button.onclick = function () {
-    var modal = document.getElementById("edit-pair-modal");
+    const modal = document.getElementById("edit-pair-modal");
 
     //display the modal
     modal.style.display = "block";
 
     //show interns to be added
-    addIntern(pair, interns);
+    addIntern(pair, index);
 
     // Get the <span> element that closes the modal
-    var span = document.getElementsByClassName("edit-close")[0];
+    const span = document.getElementsByClassName("edit-close")[0];
 
     // When the user clicks on <span> (x), close the modal
     span.onclick = function () {
@@ -34,7 +32,7 @@ export function displayAddModal(button, pair, interns) {
   };
 }
 
-function addIntern(pair, interns) {
+function addIntern(pair, index) {
   const modal = document.getElementById("edit-pair-modal");
 
   const table = document.getElementById("intern-options");
@@ -44,21 +42,17 @@ function addIntern(pair, interns) {
     table.appendChild(formatInternDetails(intern));
   }
 
-  const idx = interns.indexOf(pair);
-  console.log(idx);
+  const interns = loadPairsFromLocalStorage();
 
   document.getElementById("submit-modal").addEventListener("click", () => {
     const addedInterns = getSelectedInternsEdit();
     if (addedInterns.length < 1) {
       return;
     }
-    interns[idx] = [...pair, ...addedInterns];
-
-    console.log(interns);
-
+    interns[index] = [...pair, ...addedInterns];
     savePairsToLocalStorage(interns);
     displayInternWeekTable(interns);
-
+    updateInternsTable(addedInterns);
     modal.style.display = "none";
   });
 }

--- a/src/scripts/edit.js
+++ b/src/scripts/edit.js
@@ -5,6 +5,7 @@ import {
   displayInternTable,
 } from "./interns.js";
 import { formatInternDetails } from "./interns.js";
+import { savePairsToLocalStorage } from "./interns.js";
 
 export function displayAddModal(button, pair, interns) {
   button.onclick = function () {
@@ -48,29 +49,15 @@ function addIntern(pair, interns) {
 
   document.getElementById("submit-modal").addEventListener("click", () => {
     const addedInterns = getSelectedInternsEdit();
-
-    //console.log(addedInterns.length);
-
-    if (addedInterns.length > 0) {
-      //modify global selected interns
-      const names = addedInterns.map((intern) => intern.name);
-      internsSet.add(names);
-
-      //add new interns to pair
-      pair.push(...addedInterns);
-      interns[idx] = pair;
-
-      console.log(pair);
-
-      internPairsSet.clear();
-      for (const pair of interns) {
-        internPairsSet.add(pair);
-      }
-
-      //display new changes to week & intern card
-      displayInternWeekTable();
-      displayInternTable();
+    if (addedInterns.length < 1) {
+      return;
     }
+    interns[idx] = [...pair, ...addedInterns];
+
+    console.log(interns);
+
+    savePairsToLocalStorage(interns);
+    displayInternWeekTable(interns);
 
     modal.style.display = "none";
   });

--- a/src/scripts/interns.js
+++ b/src/scripts/interns.js
@@ -15,6 +15,15 @@ import {
 import { displayExportButton } from "./exportCSV.js";
 import { displayAddModal, displayRemoveModal } from "./edit.js";
 
+export function savePairsToLocalStorage(pairs) {
+  localStorage.setItem("internPairs", JSON.stringify(pairs));
+}
+
+export function loadPairsFromLocalStorage() {
+  const pairs = localStorage.getItem("internPairs");
+  return pairs ? JSON.parse(pairs) : [];
+}
+
 async function pairInterns() {
   const interns = getSelectedInterns();
   shuffle(interns);
@@ -45,14 +54,9 @@ function formatInternWeekDetails(intern) {
   return col;
 }
 
-export async function displayInternWeekTable() {
-  let internPairs = [];
-  if (internPairsSet.size === 0) {
-    const pairingSet = await pairInterns();
-    internPairs = Array.from(pairingSet);
-  } else {
-    internPairs = Array.from(internPairsSet);
-  }
+export async function displayInternWeekTable(savedPairs) {
+  const internPairs = savedPairs != null ? savedPairs : await pairInterns();
+  savePairsToLocalStorage(internPairs);
 
   renderDepartmentLists("department-list-2");
   const weekCard = document.getElementById("week-card-content");
@@ -82,7 +86,7 @@ export async function displayInternWeekTable() {
     addBtn.textContent = "+";
     groupNum.appendChild(addBtn);
 
-    displayAddModal(addBtn, pair, internPairs); //display add functionality
+    displayAddModal(addBtn, pair, index); //display add functionality
 
     const rmBtn = document.createElement("button"); //add edit button
     rmBtn.className = "edit";

--- a/src/style.css
+++ b/src/style.css
@@ -418,15 +418,15 @@ i#toggle-icon-week.interns {
 .export-button {
   background-color: white;
   font-weight: bold;
-  border: 4px, solid, rgb(243, 174, 142);
+  border: 4px, solid, rgb(243 174 142);
   border-radius: 25px;
   padding: 10px;
-  color: rgb(221, 156, 126);
+  color: rgb(221 156 126);
   cursor: pointer;
 }
 
 .export-button:hover {
-  background-color: rgb(243, 174, 142);
+  background-color: rgb(243 174 142);
   color: white;
 }
 
@@ -614,7 +614,7 @@ tr:nth-child(odd) {
   background: #e8f2ea;
 }
 
-/*EDITING modal*/
+/* EDITING modal */
 .edit-modal {
   display: none; /* Hidden by default */
   position: fixed; /* Stay in place */
@@ -624,8 +624,8 @@ tr:nth-child(odd) {
   width: 100%; /* Full width */
   height: 100%; /* Full height */
   overflow: auto; /* Enable scroll if needed */
-  background-color: rgb(0,0,0); /* Fallback color */
-  background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+  background-color: rgb(0 0 0); /* Fallback color */
+  background-color: rgb(0 0 0 / 40%); /* Black w/ opacity */
 }
 
 /* Modal Content/Box */

--- a/src/util/isEven.js
+++ b/src/util/isEven.js
@@ -1,0 +1,3 @@
+export default function isEven(num) {
+  return (num & 1) === 0;
+}

--- a/src/util/pair.js
+++ b/src/util/pair.js
@@ -23,9 +23,5 @@ export default function pair(arr) {
     internPairsSet.add(pairsArray[pairsArray.length - 1]);
   }
 
-  console.log(pairsArray);
-
-  //internPairs = await pairsArray;
-
-  return internPairsSet;
+  return pairsArray;
 }

--- a/src/util/pair.js
+++ b/src/util/pair.js
@@ -1,10 +1,10 @@
-import { internPairsSet } from "../constants/constants.js";
+import isEven from "./isEven.js";
 
 export default function pair(arr) {
-  const pairsArray = []; //return array with the pairings
+  const pairs = []; //return array with the pairings
 
   if (arr.length <= 1) {
-    return pairsArray;
+    return pairs;
   }
 
   const arrLast = arr.length - 1;
@@ -12,16 +12,13 @@ export default function pair(arr) {
   //iterate by twos, create item tuples and add then to return array
   for (let i = 0; i < arrLast; i += 2) {
     const pair = [arr[i], arr[i + 1]];
-    pairsArray.push(pair);
-    internPairsSet.add(pair);
+    pairs.push(pair);
   }
 
   //if odd then add last item to last pair
-  if (arr.length % 2 !== 0) {
-    internPairsSet.delete(pairsArray[pairsArray.length - 1]);
-    pairsArray[pairsArray.length - 1].push(arr[arrLast]);
-    internPairsSet.add(pairsArray[pairsArray.length - 1]);
+  if (!isEven(arr.length)) {
+    pairs[pairs.length - 1].push(arr[arrLast]);
   }
 
-  return pairsArray;
+  return pairs;
 }

--- a/src/util/pair.js
+++ b/src/util/pair.js
@@ -11,8 +11,7 @@ export default function pair(arr) {
 
   //iterate by twos, create item tuples and add then to return array
   for (let i = 0; i < arrLast; i += 2) {
-    const pair = [arr[i], arr[i + 1]];
-    pairs.push(pair);
+    pairs.push([arr[i], arr[i + 1]]);
   }
 
   //if odd then add last item to last pair


### PR DESCRIPTION
## Changes
- Intern pairs can now add interns that have not been selected

## Testing

### Select Intern
![1b95b6db1df2cc062b83fcfb923a7f29](https://github.com/user-attachments/assets/89bc8961-5b66-45e3-bdf6-eb083df71a77)

### Intern gets added to group
![d04ca1f766b62ed448ed1e69a53e0e39](https://github.com/user-attachments/assets/e174b918-5d52-4d2e-9c28-cb874d47ccfc)

### List will no longer consist of added intern from either the intern table and edit modal table
![Uploading 5881a8b0f8cd07530e03ff6d9f025c2c.png…]()


## Purpose
- To override generated schedules